### PR TITLE
Copy built libraries to JAVA_HOME

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/
 build/
 cryptobox4J.iml
+cryptobox.iml
 data/
 target/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean:
 	rm -f build/lib/libcryptobox-jni.$(LIB_TYPE)
 
 .PHONY: compile
-compile: cryptobox compile-native compile-java
+compile: cryptobox compile-native copy-libs compile-java
 
 .PHONY: compile-native
 compile-native:
@@ -93,3 +93,8 @@ build/lib/libsodium.$(LIB_TYPE): build/src/$(LIBSODIUM)
 ifeq ($(OS), darwin)
 	install_name_tool -id "@loader_path/libsodium.dylib" build/lib/libsodium.dylib
 endif
+
+#############################################################################
+# copy libraries to java home
+copy-libs:
+	cp -r build/lib/* $$JAVA_HOME/lib


### PR DESCRIPTION
In the current master branch, when the libraries are built, they are not copied anywhere so when the maven tests are executed, the java can not pick the libraries.

I added simple copy command before executing maven that copies the built libraries to the `JAVA_HOME/lib` location and therefore the JVM can pick them up.