### PR TITLE
Migrate to supported JDK/JRE docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
+        if: ${{ inputs.publish }}
         with:
           username: wirebot
           password: ${{ secrets.docker_password }}

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk as cryptobox
+FROM eclipse-temurin:11-jdk as cryptobox
 
 # disable prompts from the txdata
 ENV DEBIAN_FRONTEND=noninteractive
@@ -47,7 +47,7 @@ RUN make dist
 
 ENV LD_LIBRARY_PATH=/wire/cryptobox/dist/lib
 
-FROM openjdk:11-jre-slim as runtime
+FROM eclipse-temurin:11-jre as runtime
 
 RUN mkdir -p /opt/wire/lib
 # make Java to take this as java.library.path


### PR DESCRIPTION
* use jvm 11 -> these builds will receive support until at least October 2024 - https://adoptium.net/en-GB/support/
* in the future migrate to JVM 17 
    *  currently not possible, because prometheus exporter breaks build -> migrate to latest version that should build on jvm 17