### PR TITLE
chore: use JDK 17

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
 
       - name: Set Release Version
         # use the version specified in the pom.xml as the tag

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
 
       - name: Build with Maven
         run: mvn -DskipTests package
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with: # running setup-java again overwrites the settings.xml
           distribution: 'temurin'
-          java-version: 8
+          java-version: 17
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See makefiles in [mk](mk) directory.
 <dependency>
     <groupId>com.wire</groupId>
     <artifactId>cryptobox4j</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-jdk as cryptobox
+FROM eclipse-temurin:17-jdk as cryptobox
 
 # disable prompts from the txdata
 ENV DEBIAN_FRONTEND=noninteractive
@@ -47,7 +47,7 @@ RUN make dist
 
 ENV LD_LIBRARY_PATH=/wire/cryptobox/dist/lib
 
-FROM eclipse-temurin:11-jre as runtime
+FROM eclipse-temurin:17-jre as runtime
 
 RUN mkdir -p /opt/wire/lib
 # make Java to take this as java.library.path

--- a/mk/prometheus-agent-src.mk
+++ b/mk/prometheus-agent-src.mk
@@ -1,4 +1,4 @@
-PROMETHEUS_AGENT_VERSION := 0.14.0
+PROMETHEUS_AGENT_VERSION := 0.19.0
 PROMETHEUS_AGENT_NAME    := prometheus-java-agent
 PROMETHEUS_AGENT_GIT_URL := https://github.com/prometheus/jmx_exporter.git
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>cryptobox4j</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <name>Cryptobox4J</name>
     <description>CryptoBox for Wire Bots</description>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.0</version>
                 <configuration>
                     <!-- Prevent gpg from using pinentry programs -->
                     <gpgArguments>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M8</version>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The created docker images have JDK 11 inside. Making it impossible to run newer software, considering that JDK 17 is the most recent LTS version.

### Solutions

Upgrade the docker images to JDK 17, and use JDK 17 on CI to match.

Had to upgrade jmx_exporter to 0.19.0 in order to support building it with newer JDK as well.

> **Note**
> This PR also upgrades the version to `1.4.0` so current users of the `1.3.0` docker images can still use JDK 11 without issues.

### Testing

Built it locally and it's working. The docker image is built successfully with the correct artifacts and JDK 17:

![image](https://github.com/wireapp/cryptobox4j/assets/9389043/2865d1c5-52f1-4ecf-9979-ef8485150744)


#### Test Coverage

N/A

#### How to Test

- `docker build --file Dockerfile --target cryptobox --tag wirebot/cryptobox ../` and run Java applications using Cryptobox as a dependency

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
